### PR TITLE
Fix measure.c memory leak and warnings/errors with newer gcc/glibc and vc++

### DIFF
--- a/cbmbasic/cbmbasic.c
+++ b/cbmbasic/cbmbasic.c
@@ -10,7 +10,9 @@ main()
 	void *state = initAndResetChip();
 
 	/* set up memory for user program */
-	init_monitor();
+	if (init_monitor()) {
+		return 1;
+	}
 
 	/* emulate the 6502! */
 	for (;;) {

--- a/cbmbasic/plugin.c
+++ b/cbmbasic/plugin.c
@@ -46,6 +46,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #ifdef _WIN32
 #include <windows.h>
 #undef ERROR_FILE_NOT_FOUND    /* avoid conflict with CBM value below */
@@ -243,6 +244,7 @@ plugin_gone() {
 			a = get_word();
 			check_comma();
 			b = get_byte();
+			(void)b;
 			if (a==6502) {
 				printf("MICROSOFT!");
 				continue;
@@ -262,7 +264,10 @@ plugin_gone() {
 			char s[256];
 
 			get_string(s);
-			system(s);
+			errno = 0;
+			if (system(s) == -1 && errno != 0) {
+				perror("System call failed");
+			}
 
 			continue;
 		}

--- a/cbmbasic/runtime.c
+++ b/cbmbasic/runtime.c
@@ -555,7 +555,7 @@ LOAD() {
 		struct stat st;
 		unsigned short start;
 		unsigned short end;
-		unsigned char savedbyte;
+//		unsigned char savedbyte;
 
 		if (A) {
 			printf("UNIMPL: VERIFY\n");
@@ -648,7 +648,7 @@ for (i=0; i<255; i++) {
 			goto load_noerr;
 		} /* end if( RAM[kernal_filename]=='$' ) */
 
-		savedbyte = RAM[kernal_filename+kernal_filename_len]; /* TODO possible overflow */
+//		savedbyte = RAM[kernal_filename+kernal_filename_len]; /* TODO possible overflow */
 		RAM[kernal_filename+kernal_filename_len] = 0;
 
 /* on directory filename chdir on it */
@@ -698,7 +698,7 @@ missing_file_name:
 static void
 SAVE() {
 		FILE *f;
-		unsigned char savedbyte;
+//		unsigned char savedbyte;
 		unsigned short start;
 		unsigned short end;
 
@@ -714,7 +714,7 @@ SAVE() {
 			A = KERN_ERR_MISSING_FILE_NAME;
 			return;
 		}
-		savedbyte = RAM[kernal_filename+kernal_filename_len]; /* TODO possible overflow */
+//		savedbyte = RAM[kernal_filename+kernal_filename_len]; /* TODO possible overflow */
 		RAM[kernal_filename+kernal_filename_len] = 0;
 		f = fopen((char*)&RAM[kernal_filename], "wb"); /* overwrite - these are not the COMMODORE DOS semantics! */
 		if (!f) {

--- a/cbmbasic/runtime_init.c
+++ b/cbmbasic/runtime_init.c
@@ -16,13 +16,21 @@ unsigned char A, X, Y, S, P;
 unsigned short PC;
 int N, Z, C;
 
-void
+int
 init_monitor()
 {
 	FILE *f;
-	f = fopen("cbmbasic/cbmbasic.bin", "r");
-	fread(memory + 0xA000, 1, 17591, f);
+	f = fopen("cbmbasic/cbmbasic.bin", "rb");
+	if (f == NULL) {
+		perror("Error opening cbmbasic/cbmbasic.bin");
+		return 1;
+	}
+	size_t readlen = fread(memory + 0xA000, 1, 17591, f);
 	fclose(f);
+	if (readlen != 17591) {
+		perror("Error reading cbmbasic/cbmbasic.bin");
+		return 1;
+	}
 
 	/*
 	 * fill the KERNAL jumptable with JMP $F800;
@@ -47,6 +55,7 @@ init_monitor()
 	
 	memory[0xfffc] = 0x00;
 	memory[0xfffd] = 0xF0;
+	return 0;
 }
 
 void

--- a/cbmbasic/runtime_init.h
+++ b/cbmbasic/runtime_init.h
@@ -1,1 +1,1 @@
-void init_monitor();
+int init_monitor();

--- a/measure.c
+++ b/measure.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <strings.h>
+#include <string.h>
 
 #include "perfect6502.h"
 
@@ -74,7 +74,7 @@ uint16_t initial_s, initial_p, initial_a, initial_x, initial_y;
 void
 setup_memory(uint8_t opcode)
 {
-	bzero(memory, 65536);
+	memset(memory, 0, 65536);
 
 	memory[0xFFFC] = SETUP_ADDR & 0xFF;
 	memory[0xFFFD] = SETUP_ADDR >> 8;
@@ -116,6 +116,9 @@ void *state;
 void
 resetChip_test()
 {
+	if (state != NULL) {
+		destroyChip(state);
+	}
 	state = initAndResetChip();
 	for (int i = 0; i < 62; i++)
 		step(state);
@@ -222,11 +225,12 @@ main()
 						data[opcode].izy = YES;
 					else
 						is_data_access = NO;
-					if (is_data_access)
+					if (is_data_access) {
 						if (IS_READ_CYCLE)
 							data[opcode].reads = YES;
 						if (IS_WRITE_CYCLE)
 							data[opcode].writes = YES;
+					}
 				}
 			};
 
@@ -270,7 +274,7 @@ main()
 				BOOL different = NO;
 				int reads, writes;
 				uint16_t read[100], write[100], write_data[100];
-				uint8_t end_a, end_x, end_y, end_s, end_p;
+				uint8_t end_a, end_x, end_y, end_s = 0, end_p = 0;
 				for (int j = 0; j < sizeof(magics)/sizeof(*magics); j++) {
 					setup_memory(opcode);
 					if (data[opcode].length == 2) {

--- a/netlist_sim.c
+++ b/netlist_sim.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include "types.h"
 
 /* the smallest types to fit the numbers */
@@ -387,6 +388,8 @@ getGroupValue(state_t *state)
 		case contains_nothing:
 			return NO;
 	}
+	assert(0);
+	return NO;
 }
 
 static inline void


### PR DESCRIPTION
This patch fixes warnings from gcc and glibc that prevent compilation with -Werror, updates apple1basic.c to the new API, fixes the #ifdef _WIN32 block in that file, and fixes a memory leak in measure.c.

I fixed the Makefile issue by creating a single Makefile that can build cbmbasic, apple1basic, and measure all at once or individually. However, since this changes the Makefile system from three files to one, I left it out of this pull request. If desired, I could add that. The other alternative is to comment out the OBJS+=measure.o line again.