### PR TITLE
build fix and added targets to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.orig
 *.rej
 # object files
-cbmbasic
+cbmbasic/cbmbasic
+measure
 *.o

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 OBJS=perfect6502.o netlist_sim.o
 OBJS+=cbmbasic/cbmbasic.o cbmbasic/runtime.o cbmbasic/runtime_init.o cbmbasic/plugin.o cbmbasic/console.o cbmbasic/emu.o
-OBJS+=measure.o
 CFLAGS=-Werror -Wall -O3
 CC=cc
 


### PR DESCRIPTION
cbmbasic does not build because it is linked against measure.o, which also implements an entry point. I removed the unnecessary dependency.
.gitignore currently has a pattern "cbmbasic". Therefore, any new files added to the cbmbasic directory would be ignored. I replaced the pattern by an explicit mention of the compilation target ("cbmbasic/cbmbasic"). I also added an ignore pattern for the "measure" executable.