### PR TITLE
Fix compile error: control reaches end of non-void function

### DIFF
--- a/netlist_sim.c
+++ b/netlist_sim.c
@@ -387,6 +387,8 @@ getGroupValue(state_t *state)
 		case contains_nothing:
 			return NO;
 	}
+
+        abort();
 }
 
 static inline void


### PR DESCRIPTION
Compilation fails with: control reaches end of non-void function.

I've added an abort to that path so that we don't take it by mistake.

There are also warnings turned errors in the CBM path, but I have not fixed them.