### PR TITLE
Fix uninitialized groupcount causing intermittent segfaults

### DIFF
--- a/netlist_sim.c
+++ b/netlist_sim.c
@@ -516,6 +516,7 @@ setupNodesAndTransistors(netlist_transdefs *transdefs, BOOL *node_is_pullup, nod
  
     /* group content depends on active state, not easy to predict actual size needed */
 	state->group = calloc(state->nodes, sizeof(*state->group));
+	state->groupcount = 0;
     
     /* ping pong state buffers */
 	state->list1 = calloc(state->nodes, sizeof(*state->list1));


### PR DESCRIPTION
Initialize `state->groupcount` to 0 in `setupNodesAndTransistors()`.

`group_clear()` reads `groupcount` before any `group_add()` on the first `recalcNode()` pass.  An uninitialized value caused intermittent heap-buffer-overflows that surfaced as random SIGSEGV / double-free aborts at startup (confirmed with AddressSanitizer).