### PR TITLE
Replace O(N^2) transistor deduplication with a hash set

### DIFF
--- a/netlist_sim.c
+++ b/netlist_sim.c
@@ -488,6 +488,38 @@ add_nodes_dependant(state_t *state, nodenum_t a, nodenum_t b, nodenum_t *counts,
 }
 
 
+/* Duplicate detection for the transistor list.
+    c1 and c2 are interchangeable, so a transistor's identity is the triple
+    (gate, min(c1,c2), max(c1,c2)) packed into one word. All three are
+    nodenum_t, so a valid key never sets any of the top 16 bits and ~0 is
+    free to use as the empty marker.
+*/
+typedef unsigned long long transkey_t;
+
+#define TRANSKEY_EMPTY (~(transkey_t)0)
+
+static inline transkey_t
+transistor_key(nodenum_t gate, nodenum_t c1, nodenum_t c2)
+{
+    nodenum_t lo = (c1 < c2) ? c1 : c2;
+    nodenum_t hi = (c1 < c2) ? c2 : c1;
+    return ((transkey_t)gate << 32) | ((transkey_t)lo << 16) | (transkey_t)hi;
+}
+
+/* splitmix64 finalizer - the keys are dense and highly structured, so the
+    low bits need mixing before they can be used as a bucket index */
+static inline size_t
+transistor_hash(transkey_t key)
+{
+    key ^= key >> 30;
+    key *= 0xbf58476d1ce4e5b9ULL;
+    key ^= key >> 27;
+    key *= 0x94d049bb133111ebULL;
+    key ^= key >> 31;
+    return (size_t)key;
+}
+
+
 /*  6502:
         3288 transistors, 3239 used in simulation after duplicate removal
         1725 entries in node list and used in simulation
@@ -542,26 +574,38 @@ setupNodesAndTransistors(netlist_transdefs *transdefs, BOOL *node_is_pullup, nod
 		nodes_gatecount[i] = 0;
 	}
     
-	/* Copy transistors into r/w data structure and remove duplicates */
+	/* Copy transistors into r/w data structure and remove duplicates
+        (including ones with reversed c1c2 values) */
+
+	/* an open-addressed hash set of canonical keys in O(N), sized to twice the
+        transistor count so the load factor stays at 0.5 and probing terminates */
+	size_t dedup_size = 1;
+	while (dedup_size < (size_t)state->transistors * 2)
+		dedup_size <<= 1;
+	transkey_t *dedup_keys = malloc(dedup_size * sizeof(*dedup_keys));
+	memset(dedup_keys, 0xff, dedup_size * sizeof(*dedup_keys));  /* == TRANSKEY_EMPTY */
+	const size_t dedup_mask = dedup_size - 1;
+
 	count_t transistors_used = 0;
 	for (i = 0; i < state->transistors; i++) {
 		nodenum_t gate = transdefs[i].gate;
 		nodenum_t c1 = transdefs[i].c1;
 		nodenum_t c2 = transdefs[i].c2;
-		/* skip duplicate transistors (including ones with reversed c1c2 values)
-            O(N^2) operation, but only done once at initialization, not a significant time sink */
+
+		transkey_t key = transistor_key(gate, c1, c2);
+		size_t slot = transistor_hash(key) & dedup_mask;
 		BOOL found = NO;
-		for (count_t j2 = 0; j2 < transistors_used; j2++) {
-			if (transistors_gate[j2] == gate &&
-				((transistors_c1[j2] == c1 &&
-				  transistors_c2[j2] == c2) ||
-				 (transistors_c1[j2] == c2 &&
-				  transistors_c2[j2] == c1))) {
-					 found = YES;
-                     break;
-				 }
+		while (dedup_keys[slot] != TRANSKEY_EMPTY) {
+			if (dedup_keys[slot] == key) {
+				found = YES;
+				break;
+			}
+			slot = (slot + 1) & dedup_mask;
 		}
+		/* keep the first occurrence: later initialization indexes transistors_c1/c2
+            by a prefix sum over gate counts, so the arrays must stay gate-sorted */
 		if (!found) {
+			dedup_keys[slot] = key;
 			transistors_gate[transistors_used] = gate;
 			transistors_c1[transistors_used] = c1;
 			transistors_c2[transistors_used] = c2;
@@ -569,6 +613,10 @@ setupNodesAndTransistors(netlist_transdefs *transdefs, BOOL *node_is_pullup, nod
 		}
 	}
 	state->transistors = transistors_used;
+
+    /* this is only used for duplicate removal */
+	free(dedup_keys);
+	dedup_keys = NULL;
 
 
 	/* cross reference transistors in nodes data structures */


### PR DESCRIPTION
`setupNodesAndTransistors` removes duplicate transistors by scanning the list of
survivors for each input transistor. At 3288 transistors against a list growing
to 3239, that is roughly 5.3M three-array comparisons per call.

The comment on it says:

> only done once at initialization, not a significant time sink

which holds for `cbmbasic`, and does not hold for `measure`. `measure` calls
`resetChip_test` from inside its per-opcode loops and so rebuilds chip state
22832 times per run. Setup was 51% of that profile, with this scan at the top.

This is setup cost only. It does not touch the solver, and no simulation result
changes.

# What it does instead

Detects duplicates with an open-addressed hash set, keyed on the canonical triple
`(gate, min(c1,c2), max(c1,c2))` packed into one 64-bit word. `c1` and `c2` are
interchangeable, so ordering them folds the reversed-`c1c2` case into a plain key
comparison. The table is sized to a power of two at least twice the transistor
count, keeping the load factor at or below 0.5 so linear probing always
terminates.

**The first occurrence is still the one kept, and input order is unchanged.**
Later initialisation indexes `transistors_c1`/`c2` by a prefix sum over gate counts,
so the arrays have to stay in the netlist's own gate-sorted order. A sort-based fix
would have had to sort by gate for the same reason.

# Verification

Both algorithms keep the same 3239 transistors in the same order, element for
element, on the shipped netlist. Checked directly rather than inferred.
`measure`'s 256-opcode output is byte-identical, same md5 over three runs each
side. `cbmbasic --benchmark` output is identical apart from its own timing lines.

# Performance

| workload | master | this PR | |
|---|---|---|---|
| `measure`, whole run | 106.7 s | 62.9 s | **-41%** |
| `cbmbasic`, setup plus startup | 9.5 ms | 7.7 ms | -1.8 ms |
| `cbmbasic --benchmark`, whole run | 0.855 s | 0.855 s | unchanged |

**`measure` is where this shows an effect: 41% off the whole run.**
That follows from what the change is. `measure` runs `initAndResetChip` 22832
times, so the saving per setup is collected 22832 times; 1.8 ms times 22832 is 41 s,
against a measured difference of 44 s.

`cbmbasic` sets the chip up once and so collects the saving once. Its run total
does not change. The setup row is the split at the benchmark's own internal
clock, which starts after `initAndResetChip`.

## Machine

AMD Ryzen 5 7640U (Zen 4), 6C/12T, SMT on. Frequency boost disabled, governor
`performance`, `amd_pstate=active`. Kernel 7.1.4-arch1-1, gcc 16.1.1. All runs
pinned with `taskset -c 8`, both sides built up front and never rebuilt between
runs, interleaved round-robin with the sweep direction alternating each pass. N=3
for `measure`, N=42 for the `cbmbasic` split, medians reported.

I used an LLM to help me out in this work, but I manually reviewed all changes made.