### PR TITLE
Spend memory to save work in the group walk

### DIFF
--- a/netlist_sim.c
+++ b/netlist_sim.c
@@ -112,7 +112,6 @@ typedef struct {
 
 	nodenum_t *group;
 	count_t groupcount;
-	bitmap_t *groupbitmap;
 
 } state_t;
 
@@ -270,18 +269,14 @@ listout_add(state_t *state, nodenum_t i)
  * a group is a set of connected nodes, which consequently
  * share the same value
  *
- * we use an array and a count for O(1) insert and
- * iteration, and a redundant bitmap for O(1) lookup
+ * we use an array and a count for O(1) insert and iteration, and answer
+ * membership by scanning it: groups average under two nodes, and the largest
+ * on this netlist is 54
  */
 
 static inline void
 group_clear(state_t *state)
 {
-	/* Clear only the bits we set — faster than memset for small groups */
-	bitmap_t *gb = state->groupbitmap;
-	const nodenum_t *grp = state->group;
-	for (count_t i = 0; i < state->groupcount; i++)
-		gb[grp[i]>>BITMAP_SHIFT] &= ~(ONE << (grp[i] & BITMAP_MASK));
 	state->groupcount = 0;
 }
 
@@ -289,7 +284,6 @@ static inline void
 group_add(state_t *state, nodenum_t i)
 {
 	state->group[state->groupcount++] = i;
-	set_bitmap(state->groupbitmap, i, 1);
 }
 
 static inline nodenum_t
@@ -301,7 +295,13 @@ group_get(state_t *state, count_t n)
 static inline BOOL
 group_contains(state_t *state, nodenum_t el)
 {
-	return get_bitmap(state->groupbitmap, el);
+	const nodenum_t *grp = state->group;
+	const count_t count = state->groupcount;
+
+	for (count_t i = 0; i < count; i++)
+		if (grp[i] == el)
+			return YES;
+	return NO;
 }
 
 static inline count_t
@@ -519,8 +519,7 @@ setupNodesAndTransistors(netlist_transdefs *transdefs, BOOL *node_is_pullup, nod
 	state->nodes_value = calloc(state->nodes, sizeof(*state->nodes_value));
 	state->nodes_base = calloc(state->nodes, sizeof(*state->nodes_base));
 	state->listout_bitmap = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->listout_bitmap));
-	state->groupbitmap = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->groupbitmap));
- 
+
     /* group content depends on active state, not easy to predict actual size needed */
 	state->group = calloc(state->nodes, sizeof(*state->group));
     
@@ -745,7 +744,6 @@ destroyNodesAndTransistors(state_t *state)
     free(state->list2);
     free(state->listout_bitmap);
     free(state->group);
-    free(state->groupbitmap);
     free(state);
 }
 

--- a/netlist_sim.c
+++ b/netlist_sim.c
@@ -91,7 +91,9 @@ typedef struct {
 	/* everything that describes a node */
 	bitmap_t *nodes_pullup;
 	bitmap_t *nodes_pulldown;
-	bitmap_t *nodes_value;
+	uint8_t *nodes_value;
+	/* each node's pullup/pulldown contribution, as a group_value */
+	uint8_t *nodes_base;
 	c1c2_t *nodes_c1c2s;
 	count_t *nodes_c1c2offset;
 	nodenum_t *nodes_dependant;
@@ -174,39 +176,46 @@ get_bitmap(bitmap_t *bitmap, int index)
  */
 
 static inline void
+refresh_nodes_base(state_t *state, transnum_t t)
+{
+	if (get_bitmap(state->nodes_pulldown, t))
+		state->nodes_base[t] = contains_pulldown;
+	else if (get_bitmap(state->nodes_pullup, t))
+		state->nodes_base[t] = contains_pullup;
+	else
+		state->nodes_base[t] = contains_nothing;
+}
+
+static inline void
 set_nodes_pullup(state_t *state, transnum_t t, BOOL s)
 {
 	set_bitmap(state->nodes_pullup, t, s);
-}
-
-static inline BOOL
-get_nodes_pullup(state_t *state, transnum_t t)
-{
-	return get_bitmap(state->nodes_pullup, t);
+	refresh_nodes_base(state, t);
 }
 
 static inline void
 set_nodes_pulldown(state_t *state, transnum_t t, BOOL s)
 {
 	set_bitmap(state->nodes_pulldown, t, s);
+	refresh_nodes_base(state, t);
 }
 
-static inline BOOL
-get_nodes_pulldown(state_t *state, transnum_t t)
+static inline group_value
+get_nodes_base(state_t *state, transnum_t t)
 {
-	return get_bitmap(state->nodes_pulldown, t);
+	return (group_value)state->nodes_base[t];
 }
 
 static inline void
 set_nodes_value(state_t *state, transnum_t t, BOOL s)
 {
-	set_bitmap(state->nodes_value, t, s);
+	state->nodes_value[t] = s;
 }
 
 static inline BOOL
 get_nodes_value(state_t *state, transnum_t t)
 {
-	return get_bitmap(state->nodes_value, t);
+	return state->nodes_value[t];
 }
 
 /************************************************************
@@ -331,18 +340,15 @@ addNodeToGroup(state_t *state, nodenum_t n, group_value val)
 
 	group_add(state, n);
 
-    /* Give the compiler a hint that all of these can be calculated, and don't need to wait on branches.
-       This results in a small speedup.
+    /* A node contributes the greater of its pullup/pulldown state and its own
+       value. Give the compiler a hint that both can be calculated, and don't
+       need to wait on branches. This results in a small speedup.
     */
-    BOOL isPulldown = get_nodes_pulldown(state, n);
-    BOOL isPullup = get_nodes_pullup(state, n);
-    BOOL nodeValue = get_nodes_value(state, n);
-	if (val < contains_pulldown && isPulldown)
-		val = contains_pulldown;
-	if (val < contains_pullup && isPullup)
-		val = contains_pullup;
-	if (val < contains_hi && nodeValue)
-		val = contains_hi;
+    const group_value base = get_nodes_base(state, n);
+    const group_value hi = get_nodes_value(state, n) ? contains_hi : contains_nothing;
+    const group_value contrib = base > hi ? base : hi;
+	if (val < contrib)
+		val = contrib;
     /* state can remain at contains_nothing if the node value is low */
 
 	/* revisit all transistors that control this node */
@@ -494,8 +500,8 @@ add_nodes_dependant(state_t *state, nodenum_t a, nodenum_t b, nodenum_t *counts,
         c1c2total = 6478
         block_dep_size = 7260
 
-    Working set = 89 KB allocations, 220 KB binary, plus system libs and text buffering
-                = 604 KB in release build
+    Working set = 92 KB allocations, 220 KB binary, plus system libs and text buffering
+                = 607 KB in release build
 */
 state_t *
 setupNodesAndTransistors(netlist_transdefs *transdefs, BOOL *node_is_pullup, nodenum_t nodes, nodenum_t transistors, nodenum_t vss, nodenum_t vcc)
@@ -510,7 +516,8 @@ setupNodesAndTransistors(netlist_transdefs *transdefs, BOOL *node_is_pullup, nod
 	state->nodes_c1c2offset = calloc(state->nodes + 1, sizeof(*state->nodes_c1c2offset));
 	state->nodes_pullup = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->nodes_pullup));
 	state->nodes_pulldown = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->nodes_pulldown));
-	state->nodes_value = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->nodes_value));
+	state->nodes_value = calloc(state->nodes, sizeof(*state->nodes_value));
+	state->nodes_base = calloc(state->nodes, sizeof(*state->nodes_base));
 	state->listout_bitmap = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->listout_bitmap));
 	state->groupbitmap = calloc(WORDS_FOR_BITS(state->nodes), sizeof(*state->groupbitmap));
  
@@ -730,6 +737,7 @@ destroyNodesAndTransistors(state_t *state)
     free(state->nodes_pullup);
     free(state->nodes_pulldown);
     free(state->nodes_value);
+    free(state->nodes_base);
     free(state->nodes_c1c2s);
     free(state->nodes_c1c2offset);
     free(state->dependent_block);


### PR DESCRIPTION
Two changes to how node state is stored, both trading space this program is not
short of for operations it performs tens of millions of times.

A cbmbasic run to `READY.` takes on the order of ten thousand cache misses in
total, against 2.9 billion cycles. The working set is 89 KB and lives in L2. The
bit-packing in this file was buying space that was never scarce, at the cost of a
shift and a mask on the hottest path in the program.

# One byte per node value, and a precomputed base

`nodes_value` becomes one byte per node. It is read 126 million times per run as
`get_nodes_value(c.gate)` while scanning transistors, and the whole array is 1725
bytes.

Separately, each node's pullup/pulldown contribution is precomputed into
`nodes_base`. Pullups and pulldowns only change in `setNode()` and
`writeNodes()`, a handful of nodes per half-cycle, yet `addNodeToGroup` read both
bitmaps on all 80 million group-walk steps. Every update to the running value is
a max, so the three separate compares collapse into one.

# Answer group membership by scanning the group

A group was stored twice: as an array plus a count, and as a redundant bitmap
over all 1725 nodes so that `group_contains` was O(1). Every one of the 79.9
million `addNodeToGroup` calls a run makes opens with a bitmap test, and every
one that proceeds sets a bit that `group_clear` later has to clear again.

Set that against what the structure actually holds. Two thirds of the 30 million
groups built are a single node, 98% are three or fewer, and the mean is 1.45.
Four cache lines of bitmap and three operations per node visited were being spent
to answer "is this node one of the one or two I have so far".

Dropping the bitmap makes `group_add` a single store and `group_clear` an
assignment. The search runs over one or two entries that were just written. The
walk becomes quadratic in the group size, which is the point: it is quadratic in
1.45. Groups of eight or more occur 132 times in a whole run and the largest is
54 nodes, so a full scan per insertion costs on the order of 200K comparisons
against the 210M bitmap operations removed.

# Verification

`measure` is byte-identical over all 256 opcodes, and cbmbasic reaches `READY.`
at the same half-cycle with the same end state.

Beyond the architectural state, every one of the 1725 nodes is folded into an
FNV-1a digest every 16 cycles and compared against a master build. Both suites
agree exactly: `3bbda10b350a759f` over 17,946 samples of Tom Harte's
SingleStepTests, and `2e3d527522bdd11d` over 125,000 samples of the first two
million cycles of Klaus Dormann's functional test. Changing how a value is stored
should not change the value, and this is the check that says it did not. Harte
itself is 67,159 passed, 1,711 unstable on die-dependent opcodes, 0 failed,
unchanged from master.

While developing, a build that kept the bitmap and asserted the two membership
answers agreed on every call ran the same 256 opcodes clean.

# Performance

cbmbasic to `READY.`, turbo disabled. Wall clock is the minimum of fifteen
interleaved runs, counters the minimum of five:

| | master | this PR | |
|---|---|---|---|
| wall | 0.845 s | 0.694 s | **-17.9%** |
| cycles | 2,916,838,378 | 2,412,075,307 | -17.3% |
| instructions | 7,121,314,607 | 4,832,899,885 | -32.1% |
| branch misses | 51,068,528 | 46,172,947 | -9.6% |

Split between the two commits, on cycles against each one's own parent: the
byte-per-node value and the precomputed base are -9.3%, and dropping the
membership bitmap on top of that is -8.8%.

The price is 3,018 bytes. Allocations go from 88,842 to 91,860: `nodes_value`
grows from 216 bytes to 1725, `nodes_base` adds another 1725, and the group
bitmap gives 216 back. The working set comment in `setupNodesAndTransistors` is
updated from 89 KB to 92 KB.

# Note for review

This subsumes #17. `group_clear` no longer reads `groupcount` at all, so the
uninitialised read that fix addresses stops existing rather than getting
initialised. valgrind reports it on a master build and is silent on this one.
The two do not conflict textually and either order works.

I used an LLM to help me out in this work, but I manually reviewed all changes made.